### PR TITLE
Add thread concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 ## Atomic RS
+
+All about atomics in Rust. This project is bootstraped using cargo workspaces
+
+#### Concurrency
+
+- Simple threads
+- Thread and closures 
+- Scoped threads
+
+#### Atomics 

--- a/concurrency/src/main.rs
+++ b/concurrency/src/main.rs
@@ -1,3 +1,35 @@
+use core::num;
+use std::thread;
+
 fn main() {
-    println!("Hello, world!");
+    // simple threads
+    let t1 = thread::spawn(f);
+    let t2 = thread::spawn(f);
+    t1.join().unwrap();
+    t2.join().unwrap();
+
+    // threads closure
+    let numbers = Vec::from_iter(0..=1000);
+    let t = thread::spawn(move || {
+        let n = numbers.len();
+
+        let sum = numbers.iter().sum::<usize>();
+
+        sum / n
+    });
+    let avg = t.join().unwrap();
+    println!("average: {avg}");
+
+    // scoped threads
+    
+
+
+}
+
+
+fn f() {
+    println!("Hello from another thread!");
+
+    let id = thread::current().id();
+    println!("This is my thread id: {id:?}");
 }


### PR DESCRIPTION
#### Concurrency

- Simple threads
- Thread and closures 

[Threads in Rust](https://marabos.nl/atomics/basics.html#threads)
Every program starts with exactly one thread: the main thread. This thread will execute your main function and can be used to spawn more threads if necessary.

In Rust, new threads are spawned using the std::thread::spawn function from the standard library. It takes a single argument: the function the new thread will execute. The thread stops once this function returns.

Let’s take a look at an example:

use std::thread;

fn main() {
    thread::spawn(f);
    thread::spawn(f);

    println!("Hello from the main thread.");
}

fn f() {
    println!("Hello from another thread!");

    let id = thread::current().id();
    println!("This is my thread id: {id:?}");
}
We spawn two threads that will both execute f as their main function. Both of these threads will print a message and show their thread id, while the main thread will also print its own message.

[Thread ID](https://marabos.nl/atomics/basics.html#thread-id)
The Rust standard library assigns every thread a unique identifier. This identifier is accessible through Thread::id() and is of the type ThreadId. There’s not much you can do with a ThreadId other than copying it around and checking for equality. There is no guarantee that these IDs will be assigned consecutively, only that they will be different for each thread.

If you run our example program above several times, you might notice the output varies between runs. This is the output I got on my machine during one particular run:

Hello from the main thread.
Hello from another thread!
This is my thread id:
Surprisingly, part of the output seems to be missing.

What happened here is that the main thread finished executing the main function before the newly spawned threads finished executing their functions.

Returning from main will exit the entire program, even if other threads are still running.

In this particular example, one of the newly spawned threads had just enough time to get to halfway through the second message, before the program was shut down by the main thread.

If we want to make sure the threads are finished before we return from main, we can wait for them by joining them. To do so, we have to use the JoinHandle returned by the spawn function:

fn main() {
    let t1 = thread::spawn(f);
    let t2 = thread::spawn(f);

    println!("Hello from the main thread.");

    t1.join().unwrap();
    t2.join().unwrap();
}
The .join() method waits until the thread has finished executing and returns a std::thread::Result. If the thread did not successfully finish its function because it panicked, this will contain the panic message. We could attempt to handle that situation, or just call .unwrap() to panic when joining a panicked thread.

Running this version of our program will no longer result in truncated output:

Hello from the main thread.
Hello from another thread!
This is my thread id: ThreadId(3)
Hello from another thread!
This is my thread id: ThreadId(2)
The only thing that still changes between runs is the order in which the messages are printed:

Hello from the main thread.
Hello from another thread!
Hello from another thread!
This is my thread id: ThreadId(2)
This is my thread id: ThreadId(3)
[Output Locking](https://marabos.nl/atomics/basics.html#output-locking)
The println macro uses std::io::Stdout::lock() to make sure its output does not get interrupted. A println!() expression will wait until any concurrently running one is finished before writing any output. If this was not the case, we could’ve gotten more interleaved output such as:

Hello fromHello from another thread!
 another This is my threthreadHello fromthread id: ThreadId!
( the main thread.
2)This is my thread
id: ThreadId(3)
Rather than passing the name of a function to std::thread::spawn, as in our example above, it’s far more common to pass it a closure. This allows us to capture values to move into the new thread:

let numbers = vec![1, 2, 3];

thread::spawn(move || {
    for n in &numbers {
        println!("{n}");
    }
}).join().unwrap();
Here, ownership of numbers is transferred to the newly spawned thread, since we used a move closure. If we had not used the move keyword, the closure would have captured numbers by reference. This would have resulted in a compiler error, since the new thread might outlive that variable.

Since a thread might run until the very end of the program’s execution, the spawn function has a 'static lifetime bound on its argument type. In other words, it only accepts functions that may be kept around forever. A closure capturing a local variable by reference may not be kept around forever, since that reference would become invalid the moment the local variable ceases to exist.

Getting a value back out of the thread is done by returning it from the closure. This return value can be obtained from the Result returned by the join method:

let numbers = Vec::from_iter(0..=1000);

let t = thread::spawn(move || {
    let len = numbers.len();
    let sum = numbers.iter().sum::<usize>();
    sum / len  1
});

let average = t.join().unwrap(); 2

println!("average: {average}");
Here, the value returned by the thread’s closure (1) is sent back to the main thread through the join method (2).

If numbers had been empty, the thread would’ve panicked while trying to divide by zero (1), and join would’ve returned that panic message instead, causing the main thread to panic too because of unwrap (2).

[Thread Builder](https://marabos.nl/atomics/basics.html#thread-builder)
The std::thread::spawn function is actually just a convenient shorthand for std::thread::Builder::new().spawn().unwrap().

A std::thread::Builder allows you to set some settings for the new thread before spawning it. You can use it to configure the stack size for the new thread and to give the new thread a name. The name of a thread is available through std::thread::current().name(), will be used in panic messages, and will be visible in monitoring and debugging tools on most platforms.

Additionally, Builder's spawn function returns an std::io::Result, allowing you to handle situations where spawning a new thread fails. This might happen if the operating system runs out of memory, or if resource limits have been applied to your program. The std::thread::spawn function simply panics if it is unable to spawn a new thread.